### PR TITLE
added achievement/delete-by-name endpoint

### DIFF
--- a/app/backend/src/main/java/com/app/gamereview/controller/AchievementController.java
+++ b/app/backend/src/main/java/com/app/gamereview/controller/AchievementController.java
@@ -55,6 +55,15 @@ public class AchievementController {
         return ResponseEntity.ok(achievement);
     }
 
+    @DeleteMapping("/delete-by-name")
+    @AuthorizationRequired
+    @AdminRequired
+    public ResponseEntity<Achievement> deleteAchievementByName(@RequestParam String achievementName, @RequestParam String gameName,
+                                                               @RequestHeader String Authorization, HttpServletRequest request) {
+        Achievement achievement = achievementService.deleteAchievement(achievementName, gameName);
+        return ResponseEntity.ok(achievement);
+    }
+
     @GetMapping("/get-game-achievements")
     public ResponseEntity<List<Achievement>> getGameAchievements(@RequestParam String gameId) {
         List<Achievement> gameAchievements = achievementService.getGameAchievements(gameId);

--- a/app/backend/src/main/java/com/app/gamereview/service/AchievementService.java
+++ b/app/backend/src/main/java/com/app/gamereview/service/AchievementService.java
@@ -120,6 +120,38 @@ public class AchievementService {
         return achievementToDelete;
     }
 
+    public Achievement deleteAchievement(String achievementName, String gameName) {
+        List<Achievement> achievementWithName = achievementRepository.findByTitleAndIsDeletedFalse(achievementName);
+
+        if (achievementWithName.isEmpty()) {
+            throw new ResourceNotFoundException("Achievement with the given name is not found.");
+        }
+
+        Optional<Game> gameWithName = gameRepository.findByGameNameAndIsDeletedFalse(gameName);
+
+        if (gameWithName.isEmpty()) {
+            throw new ResourceNotFoundException("Game with the given name is not found.");
+        }
+
+        Achievement achievementToDelete = null;
+
+        for (Achievement achievement : achievementWithName) {
+            Optional<Game> game = gameRepository.findByIdAndIsDeletedFalse(achievement.getGame());
+            if (game.isPresent() && game.get().getGameName().equals(gameName)) {
+                achievementToDelete = achievement;
+            }
+        }
+
+        if (achievementToDelete == null) {
+            throw new ResourceNotFoundException("There is no achievement with the given name in the game.");
+        }
+
+        achievementToDelete.setIsDeleted(true);
+
+        achievementRepository.save(achievementToDelete);
+        return achievementToDelete;
+    }
+
     public List<String> grantAchievement(GrantAchievementRequestDto request) {
         Optional<Achievement> achievementOptional = achievementRepository.findByIdAndIsDeletedFalse(request.getAchievementId());
 


### PR DESCRIPTION
Since the admin may not know the id of the achievement now there is an additional endpoint that deletes by name of the game and name of the achievement. The game name is required because achievements can share names as long as they do not share games. 