### PR TITLE
arrays as query parameter fix (axios)

### DIFF
--- a/app/backend/src/main/java/com/app/gamereview/GamereviewApplication.java
+++ b/app/backend/src/main/java/com/app/gamereview/GamereviewApplication.java
@@ -1,7 +1,11 @@
 package com.app.gamereview;
 
+import org.apache.coyote.http11.AbstractHttp11Protocol;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class GamereviewApplication {
@@ -10,4 +14,11 @@ public class GamereviewApplication {
 		SpringApplication.run(GamereviewApplication.class, args);
 	}
 
+	@Bean
+	public WebServerFactoryCustomizer<TomcatServletWebServerFactory> tomcatCustomizer() {
+		return (tomcat) -> {
+			tomcat.addConnectorCustomizers((connector) ->
+					((AbstractHttp11Protocol<?>)connector.getProtocolHandler()).setRelaxedQueryChars("[]"));
+		};
+	}
 }


### PR DESCRIPTION
* Axios generates url like "...?tags[]=<some-tag-id>&tags[]=<some-other-tag-id>..." which shouldn't be the case in modern web standards
* This PR includes some adjustments on Spring's Tomcat server to accept such query parameters also