### PR TITLE
Top-bar navigation fix

### DIFF
--- a/app/frontend/src/Layout/TopBar/TopBar.tsx
+++ b/app/frontend/src/Layout/TopBar/TopBar.tsx
@@ -94,7 +94,6 @@ function TopBar() {
       <Menu
         className={styles.menu}
         mode="horizontal"
-        defaultSelectedKeys={["games"]}
         items={isLoggedIn ? itemsLoggedIn : itemsNotLoggedIn}
         theme="dark"
         onClick={({ key }) => {


### PR DESCRIPTION
Deletes default selected keys for navigation in order to not go back to games on the menu when the page is refreshed.