### PR TITLE
configured annotation cors config 

### DIFF
--- a/app/annotation/annotation/src/main/java/com/app/annotation/config/CorsConfig.java
+++ b/app/annotation/annotation/src/main/java/com/app/annotation/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         final CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173", "http://ec2-51-20-78-40.eu-north-1.compute.amazonaws.com/"));
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173", "http://localhost", "http://ec2-51-20-78-40.eu-north-1.compute.amazonaws.com/"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowCredentials(true);
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Set-Cookie", "credentials"));


### PR DESCRIPTION
this change is required because in the new port configuration of docker compose, frontend started to use port 80 instead of 5173 (previous) 